### PR TITLE
Fix invalid method name in recovery code doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ import dev.samstevens.totp.recovery.RecoveryCodeGenerator;
 ...
 // Generate 16 random recovery codes
 RecoveryCodeGenerator recoveryCodes = new RecoveryCodeGenerator();
-String[] codes = recoveryCodes.generate(16);
+String[] codes = recoveryCodes.generateCodes(16);
 // codes = ["efixm-g7fds", "4u3uc-xij2u", "vba7i-3fpny", "cmxf4-shn26", ...]
 ```
 


### PR DESCRIPTION
Method generate(int) was used in documentation for the recoverty code example.
But RecoveryCodeGenerator class method name is generateCodes()