### PR TITLE
Throws exception if DefaultCodeGenerator received null hash algo

### DIFF
--- a/src/main/java/dev/samstevens/totp/code/DefaultCodeGenerator.java
+++ b/src/main/java/dev/samstevens/totp/code/DefaultCodeGenerator.java
@@ -22,6 +22,9 @@ public class DefaultCodeGenerator implements CodeGenerator {
     }
 
     public DefaultCodeGenerator(HashingAlgorithm algorithm, int digits) {
+        if (algorithm == null) {
+            throw new InvalidParameterException("HashingAlgorithm must not be null.");
+        }
         if (digits < 1) {
             throw new InvalidParameterException("Number of digits must be higher than 0.");
         }

--- a/src/test/java/dev/samstevens/totp/code/DefaultCodeGeneratorTest.java
+++ b/src/test/java/dev/samstevens/totp/code/DefaultCodeGeneratorTest.java
@@ -33,6 +33,11 @@ public class DefaultCodeGeneratorTest {
     }
 
     @Test(expected = InvalidParameterException.class)
+    public void testInvalidHashingAlgorithmThrowsException() {
+        new DefaultCodeGenerator(null, 6);
+    }
+    
+    @Test(expected = InvalidParameterException.class)
     public void testInvalidDigitLengthThrowsException() {
         new DefaultCodeGenerator(HashingAlgorithm.SHA1, 0);
     }


### PR DESCRIPTION
If by the DefaultCodeGenerator is instanciated with a null HashingAlgorithm (which happened to me due to invalid constant loading in a singleton...), the generator will fail during code generation with NullPointerException.

Prevent this by throwing exception in constructor.