### PR TITLE
Fix #22 - Increase recovery codes entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,13 +230,22 @@ Usually, upon registering an account for MFA, several one-time use codes will be
 
 Most of the logic needed for implementing recovery codes (storage, associating them with a user, checking for existance, etc) is implementation specific, but the codes themselves can be generated via this library.
 
+The default implementation provided in this library generates recovery codes :
+
+- of 16 characters
+- composed of numbers and lower case characters from latin alphabet (for a total of 36 possible characters)
+- split in groups separated with dash for better readability
+
+Thoses settings guarantees recovery codes security (with an entropy of 82 bits) while keeping codes simple to read and enter by end user when needed.
+
+
 ```java
 import dev.samstevens.totp.recovery.RecoveryCodeGenerator;
 ...
 // Generate 16 random recovery codes
 RecoveryCodeGenerator recoveryCodes = new RecoveryCodeGenerator();
 String[] codes = recoveryCodes.generateCodes(16);
-// codes = ["efixm-g7fds", "4u3uc-xij2u", "vba7i-3fpny", "cmxf4-shn26", ...]
+// codes = ["tf8i-exmo-3lcb-slkm", "boyv-yq75-z99k-r308", "w045-mq6w-mg1i-q12o", ...]
 ```
 
 

--- a/src/main/java/dev/samstevens/totp/recovery/RecoveryCodeGenerator.java
+++ b/src/main/java/dev/samstevens/totp/recovery/RecoveryCodeGenerator.java
@@ -1,6 +1,5 @@
 package dev.samstevens.totp.recovery;
 
-import org.apache.commons.codec.binary.Base32;
 import java.security.InvalidParameterException;
 import java.security.SecureRandom;
 import java.util.Arrays;
@@ -8,8 +7,19 @@ import java.util.Random;
 
 public class RecoveryCodeGenerator {
 
+    // Recovery code must reach a minimum entropy to be secured
+    //   code entropy = log( {characters-count} ^ {code-length} ) / log(2)
+    // the settings used below allows the code to reach an entropy of 82 bits :
+    //  log(36^16) / log(2) == 82.7...
+
+    // Recovery code must be simple to read and enter by end user when needed : 
+    //  - generate a code composed of numbers and lower case characters from latin alphabet (36 possible characters)
+    //  - split code in groups separated with dash for better readability, for example 4ckn-xspn-et8t-xgr0
+    private static final char[] CHARACTERS = "abcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
+    private static final int CODE_LENGTH = 16;
+    private static final int GROUPS_NBR = 4;
+  
     private Random random = new SecureRandom();
-    private Base32 codec = new Base32();
 
     public String[] generateCodes(int amount) {
         // Must generate at least one code
@@ -25,23 +35,19 @@ public class RecoveryCodeGenerator {
     }
 
     private String generateCode() {
-        int codeLength = 10;
-        byte[] bytes = new byte[(codeLength * 5) / 8];
-        random.nextBytes(bytes);
-        String randomCode = new String(codec.encode(bytes));
-        randomCode = randomCode.replaceAll("=", "").toLowerCase();
-
-        return splitCode(randomCode);
+        final StringBuilder code = new StringBuilder(CODE_LENGTH + (CODE_LENGTH/GROUPS_NBR) - 1);
+        
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            // Append random character from authorized ones
+            code.append(CHARACTERS[random.nextInt(CHARACTERS.length)]);
+            
+            // Split code into groups for increased readability
+            if ((i+1) % GROUPS_NBR == 0 && (i+1) != CODE_LENGTH) {
+                code.append("-");
+            }
+        }
+        
+        return code.toString();
     }
 
-    /**
-     * Split the code into two halves for readability, e.g. "a7yeh-s823k".
-     */
-    private String splitCode(String code) {
-        return String.format(
-            "%s-%s",
-            code.substring(0, (int) Math.ceil(code.length() / 2)),
-            code.substring(code.length() / 2)
-        );
-    }
 }

--- a/src/test/java/dev/samstevens/totp/recovery/RecoveryCodeGeneratorTest.java
+++ b/src/test/java/dev/samstevens/totp/recovery/RecoveryCodeGeneratorTest.java
@@ -28,7 +28,7 @@ public class RecoveryCodeGeneratorTest {
 
         // Assert each one is the correct format
         for (String code : codes) {
-            assertTrue(code.matches("[a-zA-Z0-9]{5}-[a-zA-Z0-9]{5}"));
+            assertTrue(code.matches("[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}"), code);
         }
     }
 


### PR DESCRIPTION
Change code generation :
- use a larger set of characters, yet still simple to read/enter :
numbers and lower case characters from latin alphabet
(for a total of 36 possible characters)
- increase code length, from 10 to 16
- continue to split code in groups, separated with dashes

Update unittest accordingly.

Update documentation with details on generated code format
like "mwh1-7mx0-3ly9-9whn"