### PR TITLE
Fix #24 - Limit the extensibility of classes and methods

### DIFF
--- a/src/main/java/dev/samstevens/totp/code/DefaultCodeGenerator.java
+++ b/src/main/java/dev/samstevens/totp/code/DefaultCodeGenerator.java
@@ -8,7 +8,7 @@ import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.NoSuchAlgorithmException;
 
-public class DefaultCodeGenerator implements CodeGenerator {
+public final class DefaultCodeGenerator implements CodeGenerator {
 
     private final HashingAlgorithm algorithm;
     private final int digits;

--- a/src/main/java/dev/samstevens/totp/code/DefaultCodeVerifier.java
+++ b/src/main/java/dev/samstevens/totp/code/DefaultCodeVerifier.java
@@ -3,7 +3,7 @@ package dev.samstevens.totp.code;
 import dev.samstevens.totp.exceptions.CodeGenerationException;
 import dev.samstevens.totp.time.TimeProvider;
 
-public class DefaultCodeVerifier implements CodeVerifier {
+public final class DefaultCodeVerifier implements CodeVerifier {
 
     private final CodeGenerator codeGenerator;
     private final TimeProvider timeProvider;

--- a/src/main/java/dev/samstevens/totp/exceptions/CodeGenerationException.java
+++ b/src/main/java/dev/samstevens/totp/exceptions/CodeGenerationException.java
@@ -1,6 +1,6 @@
 package dev.samstevens.totp.exceptions;
 
-public class CodeGenerationException extends Exception {
+public final class CodeGenerationException extends Exception {
     public CodeGenerationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/dev/samstevens/totp/exceptions/QrGenerationException.java
+++ b/src/main/java/dev/samstevens/totp/exceptions/QrGenerationException.java
@@ -1,6 +1,6 @@
 package dev.samstevens.totp.exceptions;
 
-public class QrGenerationException extends Exception {
+public final class QrGenerationException extends Exception {
     public QrGenerationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/dev/samstevens/totp/exceptions/TimeProviderException.java
+++ b/src/main/java/dev/samstevens/totp/exceptions/TimeProviderException.java
@@ -1,6 +1,6 @@
 package dev.samstevens.totp.exceptions;
 
-public class TimeProviderException extends RuntimeException {
+public final class TimeProviderException extends RuntimeException {
     public TimeProviderException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/dev/samstevens/totp/qr/QrData.java
+++ b/src/main/java/dev/samstevens/totp/qr/QrData.java
@@ -7,7 +7,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 @SuppressWarnings("WeakerAccess")
-public class QrData {
+public final class QrData {
 
     private final String type;
     private final String label;

--- a/src/main/java/dev/samstevens/totp/qr/ZxingPngQrGenerator.java
+++ b/src/main/java/dev/samstevens/totp/qr/ZxingPngQrGenerator.java
@@ -8,7 +8,7 @@ import com.google.zxing.qrcode.QRCodeWriter;
 import dev.samstevens.totp.exceptions.QrGenerationException;
 import java.io.ByteArrayOutputStream;
 
-public class ZxingPngQrGenerator implements QrGenerator {
+public final class ZxingPngQrGenerator implements QrGenerator {
 
     private final Writer writer;
     private int imageSize = 350;

--- a/src/main/java/dev/samstevens/totp/recovery/RecoveryCodeGenerator.java
+++ b/src/main/java/dev/samstevens/totp/recovery/RecoveryCodeGenerator.java
@@ -6,7 +6,7 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Random;
 
-public class RecoveryCodeGenerator {
+public final class RecoveryCodeGenerator {
 
     private Random random = new SecureRandom();
     private Base32 codec = new Base32();

--- a/src/main/java/dev/samstevens/totp/secret/DefaultSecretGenerator.java
+++ b/src/main/java/dev/samstevens/totp/secret/DefaultSecretGenerator.java
@@ -4,7 +4,7 @@ import org.apache.commons.codec.binary.Base32;
 import java.security.SecureRandom;
 
 @SuppressWarnings("WeakerAccess")
-public class DefaultSecretGenerator implements SecretGenerator {
+public final class DefaultSecretGenerator implements SecretGenerator {
 
     private final SecureRandom randomBytes = new SecureRandom();
     private final static Base32 encoder = new Base32();

--- a/src/main/java/dev/samstevens/totp/time/NtpTimeProvider.java
+++ b/src/main/java/dev/samstevens/totp/time/NtpTimeProvider.java
@@ -6,7 +6,7 @@ import org.apache.commons.net.ntp.TimeInfo;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-public class NtpTimeProvider implements TimeProvider {
+public final class NtpTimeProvider implements TimeProvider {
 
     private final NTPUDPClient client;
     private final InetAddress ntpHost;

--- a/src/main/java/dev/samstevens/totp/time/SystemTimeProvider.java
+++ b/src/main/java/dev/samstevens/totp/time/SystemTimeProvider.java
@@ -3,7 +3,7 @@ package dev.samstevens.totp.time;
 import dev.samstevens.totp.exceptions.TimeProviderException;
 import java.time.Instant;
 
-public class SystemTimeProvider implements TimeProvider {
+public final class SystemTimeProvider implements TimeProvider {
     @Override
     public long getTime() throws TimeProviderException {
         return Instant.now().getEpochSecond();

--- a/src/main/java/dev/samstevens/totp/util/Utils.java
+++ b/src/main/java/dev/samstevens/totp/util/Utils.java
@@ -2,7 +2,7 @@ package dev.samstevens.totp.util;
 
 import org.apache.commons.codec.binary.Base64;
 
-public class Utils {
+public final class Utils {
     private static Base64 base64Codec = new Base64();
 
     // Class not meant to be instantiated


### PR DESCRIPTION
Apply Guideline 4-5 / EXTEND-5: Limit the extensibility of classes and
methods from the Secure Coding Guidelines for Java SE
https://www.oracle.com/technetwork/java/seccodeguide-139067.html#4-5

(reported by running VisualCodeGrepper
https://github.com/nccgroup/VCG/blob/master/VisualCodeGrepper/modJavaCheck.vb#L318
)