### PR TITLE
Fix NtpTimeProvider

### DIFF
--- a/totp/src/main/java/dev/samstevens/totp/exceptions/TimeProviderException.java
+++ b/totp/src/main/java/dev/samstevens/totp/exceptions/TimeProviderException.java
@@ -1,6 +1,9 @@
 package dev.samstevens.totp.exceptions;
 
 public class TimeProviderException extends RuntimeException {
+    public TimeProviderException(String message) {
+        super(message);
+    }
     public TimeProviderException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/totp/src/main/java/dev/samstevens/totp/time/NtpTimeProvider.java
+++ b/totp/src/main/java/dev/samstevens/totp/time/NtpTimeProvider.java
@@ -46,7 +46,7 @@ public class NtpTimeProvider implements TimeProvider {
         }
 
         if (timeInfo.getOffset() == null) {
-            throw new TimeProviderException("Failed to calculate NTP offset", null);
+            throw new TimeProviderException("Failed to calculate NTP offset");
         }
 
         return (System.currentTimeMillis() + timeInfo.getOffset()) / 1000;

--- a/totp/src/main/java/dev/samstevens/totp/time/NtpTimeProvider.java
+++ b/totp/src/main/java/dev/samstevens/totp/time/NtpTimeProvider.java
@@ -37,13 +37,19 @@ public class NtpTimeProvider implements TimeProvider {
 
     @Override
     public long getTime() throws TimeProviderException {
+        TimeInfo timeInfo;
         try {
-            TimeInfo timeInfo = client.getTime(ntpHost);
-
-            return (long) Math.floor(timeInfo.getReturnTime() / 1000L);
+            timeInfo = client.getTime(ntpHost);
+            timeInfo.computeDetails();
         } catch (Exception e) {
             throw new TimeProviderException("Failed to provide time from NTP server. See nested exception.", e);
         }
+
+        if (timeInfo.getOffset() == null) {
+            throw new TimeProviderException("Failed to calculate NTP offset", null);
+        }
+
+        return (System.currentTimeMillis() + timeInfo.getOffset()) / 1000;
     }
 
     private void checkHasDependency(String dependentClass) {


### PR DESCRIPTION
`timeInfo.getReturnTime()` is the _local_ timestamp of the ntp reply.

To properly use the Ntp it is needed to:
- call `timeInfo.computeDetails()` to compute the NTP offset
- Add `timeInfo.getOffset()` to the local timestamp

This PR fix #37 